### PR TITLE
Sonarr: Add series banner image to notification

### DIFF
--- a/sonarr.sh
+++ b/sonarr.sh
@@ -6,6 +6,8 @@ ntfy_topic="mytopic"
 ntfy_username=""
 ntfy_password=""
 ntfy_token=""
+sonarr_api_key=""
+sonarr_url=""
 # Leave empty if you do not want an icon.
 ntfy_icon="https://raw.githubusercontent.com/Sonarr/Sonarr/develop/Logo/48.png"
 
@@ -27,6 +29,8 @@ if [ "$sonarr_eventtype" == "Test" ]; then
   ntfy_tag=information_source
   ntfy_title="Testing"
 elif [ "$sonarr_eventtype" == "Download" ]; then
+  response=$(curl -X GET -H "Content-Type: application/json" -H "X-Api-Key: $sonarr_api_key" "$sonarr_url/$sonarr_series_id")
+  banner_image=$(echo "$response" | jq -r '.images[0].remoteUrl')
   ntfy_tag=tv
   ntfy_title+=" - S"
   ntfy_title+="$sonarr_episodefile_seasonnumber"
@@ -60,6 +64,7 @@ ntfy_post_data()
   "topic": "$ntfy_topic",
   "tags": ["$ntfy_tag"],
   "icon": "$ntfy_icon",
+  "attach": "$banner_image",   
   "title": "Sonarr: $sonarr_eventtype",
   "message": "$ntfy_title$ntfy_message",
   "actions": [

--- a/sonarr.sh
+++ b/sonarr.sh
@@ -7,6 +7,7 @@ ntfy_username=""
 ntfy_password=""
 ntfy_token=""
 sonarr_api_key=""
+#Your Sonarr URL with no trailing slash
 sonarr_url=""
 # Leave empty if you do not want an icon.
 ntfy_icon="https://raw.githubusercontent.com/Sonarr/Sonarr/develop/Logo/48.png"
@@ -29,7 +30,7 @@ if [ "$sonarr_eventtype" == "Test" ]; then
   ntfy_tag=information_source
   ntfy_title="Testing"
 elif [ "$sonarr_eventtype" == "Download" ]; then
-  response=$(curl -X GET -H "Content-Type: application/json" -H "X-Api-Key: $sonarr_api_key" "$sonarr_url/$sonarr_series_id")
+  response=$(curl -X GET -H "Content-Type: application/json" -H "X-Api-Key: $sonarr_api_key" "$sonarr_url/api/v3/series/$sonarr_series_id")
   banner_image=$(echo "$response" | jq -r '.images[0].remoteUrl')
   ntfy_tag=tv
   ntfy_title+=" - S"


### PR DESCRIPTION
This pull request  retrieves  the banner image of the series and attaches it to the notification for the Download eventtype.

Two new variables: $sonarr_url and $sonarr_api_key, along with the sonarr supplied $sonarr_series_id variable are used to construct an api call to sonarr and retrieve the series banner image RemoteUrl, which is added to the JSON body as an attachment. 

This results in a prettier new episode notification 

This method adds the requirement of having **jq** installed on the sonarr host